### PR TITLE
S3URLパースのコードを修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-    "editor.formatOnSave": true,
-    "editor.formatOnPaste": true,
+    "editor.formatOnSave": false,
+    "editor.formatOnPaste": false,
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.codeActionsOnSave": {
       "source.fixAll": "explicit"

--- a/packages/cdk/ecs/ingest-data/app/utils.py
+++ b/packages/cdk/ecs/ingest-data/app/utils.py
@@ -15,21 +15,26 @@ from langchain_community.document_loaders import (
 s3_client = boto3.client("s3")
 
 
-def parse_s3_url(s3_url):
-    # 仮想ホスト形式の URL から、bucket, key, suffix を抽出する
-    # 例) https://bucket-name.s3.ap-northeast-1.amazonaws.com/key.txt
-    # bucket -> bucket-name, key -> key.txt, extension -> .txt
-    url = urlparse(s3_url)
-
-    bucket = url.netloc.split(".")[0]
-    key = url.path.lstrip("/")
-    extension = os.path.splitext(key)[1]
+def parse_s3_uri(s3_uri):
+    """
+    S3のURIをバケット名、キー名、拡張子に分割する
+    
+    Args:
+        s3_uri (str): 例's3://bucket_name/test/test.txt'
+    Returns:
+        bucket: バケット名(bucket_name)
+        key: キー名(test/test.txt)
+        extension: 拡張子(.txt)
+    """
+    bucket = s3_uri.split("//")[1].split("/")[0]
+    key = '/'.join(s3_uri.split("//")[1].split("/")[1:])
+    extension = os.path.splitext(key)[-1]
 
     return bucket, key, extension
 
 
 def read_file(file_url):
-    bucket, key, extension = parse_s3_url(file_url)
+    bucket, key, extension = parse_s3_uri(file_url)
 
     text = ""
 

--- a/packages/cdk/ecs/ingest-data/app/utils.py
+++ b/packages/cdk/ecs/ingest-data/app/utils.py
@@ -3,7 +3,6 @@ import tempfile
 import os
 
 # from unstructured.partition.auto import partition
-from urllib.parse import urlparse
 from langchain_community.document_loaders import (
     Docx2txtLoader,
     TextLoader,
@@ -18,7 +17,7 @@ s3_client = boto3.client("s3")
 def parse_s3_uri(s3_uri):
     """
     S3のURIをバケット名、キー名、拡張子に分割する
-    
+
     Args:
         s3_uri (str): 例's3://bucket_name/test/test.txt'
     Returns:
@@ -27,7 +26,7 @@ def parse_s3_uri(s3_uri):
         extension: 拡張子(.txt)
     """
     bucket = s3_uri.split("//")[1].split("/")[0]
-    key = '/'.join(s3_uri.split("//")[1].split("/")[1:])
+    key = "/".join(s3_uri.split("//")[1].split("/")[1:])
     extension = os.path.splitext(key)[-1]
 
     return bucket, key, extension
@@ -38,9 +37,7 @@ def read_file(file_url):
 
     text = ""
 
-    with tempfile.NamedTemporaryFile(
-        delete=True, suffix=extension
-    ) as temp_file:
+    with tempfile.NamedTemporaryFile(delete=True, suffix=extension) as temp_file:
         temp_file_path = temp_file.name
         s3_client.download_file(bucket, key, temp_file_path)
 
@@ -50,18 +47,14 @@ def read_file(file_url):
             text = load_text(temp_file_path)
         if extension == ".pdf":
             text = load_pdf(temp_file_path)
-            text = (
-                text.replace("\n", "").replace("\r", "").replace("\u00A0", " ")
-            )
+            text = text.replace("\n", "").replace("\r", "").replace("\u00A0", " ")
         if extension == ".docx":
             text = load_word(temp_file_path)
         if extension == ".pptx":
             text = load_ppt(temp_file_path)
         if extension == ".html":
             text = load_html(temp_file_path)
-            text = (
-                text.replace("\n", "").replace("\r", "").replace("\u00A0", " ")
-            )
+            text = text.replace("\n", "").replace("\r", "").replace("\u00A0", " ")
 
     return text
 
@@ -155,9 +148,7 @@ def get_all_filepath(file_url):
                 Bucket=bucket_name, Prefix=prefix, StartAfter=start_after
             )
             if "Contents" in objects:
-                file_list.extend(
-                    ([content["Key"] for content in objects["Contents"]])
-                )
+                file_list.extend(([content["Key"] for content in objects["Contents"]]))
 
     return file_list
 
@@ -176,9 +167,7 @@ def get_all_keys(file_url):
                 Bucket=bucket_name, Prefix=prefix, StartAfter=start_after
             )
             if "Contents" in objects:
-                file_list.extend(
-                    ([content["Key"] for content in objects["Contents"]])
-                )
+                file_list.extend(([content["Key"] for content in objects["Contents"]]))
 
     return file_list
 


### PR DESCRIPTION
*Description of changes:*
ファイル名に#が含まれている場合にエラーが生じるため、S3URLのパースのコードを修正
urlparseを利用するのではなく、単純に/でsplitするように変更
入力はS3 のURL形式ではなく、S3 URI(s3://xxxxx)の形式のみを想定


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
